### PR TITLE
Update Minecraft Wiki links to new domain

### DIFF
--- a/1.17.0.0/1.17.30.23/Item.html
+++ b/1.17.0.0/1.17.30.23/Item.html
@@ -174,7 +174,7 @@ An index or MoLang expression for which frame of the icon to display. Default re
 
 <h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.17.0.0/1.17.30.24/Item.html
+++ b/1.17.0.0/1.17.30.24/Item.html
@@ -174,7 +174,7 @@ An index or MoLang expression for which frame of the icon to display. Default re
 
 <h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.17.0.0/1.17.30.4/Item.html
+++ b/1.17.0.0/1.17.30.4/Item.html
@@ -173,7 +173,7 @@ An index or MoLang expression for which frame of the icon to display. Default re
 
 <h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.17.0.0/1.17.40.20/Item.html
+++ b/1.17.0.0/1.17.40.20/Item.html
@@ -174,7 +174,7 @@ An index or MoLang expression for which frame of the icon to display. Default re
 
 <h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.17.0.0/1.17.40.21/Item.html
+++ b/1.17.0.0/1.17.40.21/Item.html
@@ -174,7 +174,7 @@ An index or MoLang expression for which frame of the icon to display. Default re
 
 <h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.17.0.0/1.17.40.23/Item.html
+++ b/1.17.0.0/1.17.40.23/Item.html
@@ -174,7 +174,7 @@ An index or MoLang expression for which frame of the icon to display. Default re
 
 <h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.17.0.0/1.17.40.6/Item.html
+++ b/1.17.0.0/1.17.40.6/Item.html
@@ -173,7 +173,7 @@ An index or MoLang expression for which frame of the icon to display. Default re
 
 <h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.18.0.0/1.18.0.2/Item.html
+++ b/1.18.0.0/1.18.0.2/Item.html
@@ -173,7 +173,7 @@ An index or MoLang expression for which frame of the icon to display. Default re
 
 <h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.18.0.0/1.18.0.20/Item.html
+++ b/1.18.0.0/1.18.0.20/Item.html
@@ -174,7 +174,7 @@ An index or MoLang expression for which frame of the icon to display. Default re
 
 <h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.18.0.0/1.18.0.21/Item.html
+++ b/1.18.0.0/1.18.0.21/Item.html
@@ -174,7 +174,7 @@ An index or MoLang expression for which frame of the icon to display. Default re
 
 <h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.18.0.0/1.18.0.22/Item.html
+++ b/1.18.0.0/1.18.0.22/Item.html
@@ -174,7 +174,7 @@ An index or MoLang expression for which frame of the icon to display. Default re
 
 <h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.18.0.0/1.18.0.24/Item.html
+++ b/1.18.0.0/1.18.0.24/Item.html
@@ -174,7 +174,7 @@ An index or MoLang expression for which frame of the icon to display. Default re
 
 <h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.18.0.0/1.18.0.25/Item.html
+++ b/1.18.0.0/1.18.0.25/Item.html
@@ -174,7 +174,7 @@ An index or MoLang expression for which frame of the icon to display. Default re
 
 <h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.18.0.0/1.18.0.27/Item.html
+++ b/1.18.0.0/1.18.0.27/Item.html
@@ -174,7 +174,7 @@ An index or MoLang expression for which frame of the icon to display. Default re
 
 <h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.18.0.0/1.18.1.2/Item.html
+++ b/1.18.0.0/1.18.1.2/Item.html
@@ -173,7 +173,7 @@ An index or MoLang expression for which frame of the icon to display. Default re
 
 <h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.18.0.0/1.18.10.20/Item.html
+++ b/1.18.0.0/1.18.10.20/Item.html
@@ -170,7 +170,7 @@ How long in seconds will this fuel cook items for.</br>Minimum value: 0.05</br>T
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.18.0.0/1.18.10.21/Item.html
+++ b/1.18.0.0/1.18.10.21/Item.html
@@ -170,7 +170,7 @@ How long in seconds will this fuel cook items for.</br>Minimum value: 0.05</br>T
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.18.0.0/1.18.10.22/Item.html
+++ b/1.18.0.0/1.18.10.22/Item.html
@@ -170,7 +170,7 @@ How long in seconds will this fuel cook items for.</br>Minimum value: 0.05</br>T
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.18.0.0/1.18.10.24/Item.html
+++ b/1.18.0.0/1.18.10.24/Item.html
@@ -170,7 +170,7 @@ How long in seconds will this fuel cook items for.</br>Minimum value: 0.05</br>T
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.18.0.0/1.18.10.26/Item.html
+++ b/1.18.0.0/1.18.10.26/Item.html
@@ -170,7 +170,7 @@ How long in seconds will this fuel cook items for.</br>Minimum value: 0.05</br>T
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.18.0.0/1.18.10.27/Item.html
+++ b/1.18.0.0/1.18.10.27/Item.html
@@ -170,7 +170,7 @@ How long in seconds will this fuel cook items for.</br>Minimum value: 0.05</br>T
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.18.0.0/1.18.10.28/Item.html
+++ b/1.18.0.0/1.18.10.28/Item.html
@@ -170,7 +170,7 @@ How long in seconds will this fuel cook items for.</br>Minimum value: 0.05</br>T
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.18.0.0/1.18.10.4/Item.html
+++ b/1.18.0.0/1.18.10.4/Item.html
@@ -169,7 +169,7 @@ How long in seconds will this fuel cook items for.</br>Minimum value: 0.05</br>T
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.18.0.0/1.18.20.21/Item.html
+++ b/1.18.0.0/1.18.20.21/Item.html
@@ -170,7 +170,7 @@ How long in seconds will this fuel cook items for.</br>Minimum value: 0.05</br>T
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.18.0.0/1.18.20.23/Item.html
+++ b/1.18.0.0/1.18.20.23/Item.html
@@ -170,7 +170,7 @@ How long in seconds will this fuel cook items for.</br>Minimum value: 0.05</br>T
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.18.0.0/1.18.30.20/Item.html
+++ b/1.18.0.0/1.18.30.20/Item.html
@@ -170,7 +170,7 @@ How long in seconds will this fuel cook items for.</br>Minimum value: 0.05</br>T
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.18.0.0/1.18.30.22/Item.html
+++ b/1.18.0.0/1.18.30.22/Item.html
@@ -170,7 +170,7 @@ How long in seconds will this fuel cook items for.</br>Minimum value: 0.05</br>T
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.18.0.0/1.18.30.26/Item.html
+++ b/1.18.0.0/1.18.30.26/Item.html
@@ -170,7 +170,7 @@ How long in seconds will this fuel cook items for.</br>Minimum value: 0.05</br>T
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.18.0.0/1.18.30.28/Item.html
+++ b/1.18.0.0/1.18.30.28/Item.html
@@ -170,7 +170,7 @@ How long in seconds will this fuel cook items for.</br>Minimum value: 0.05</br>T
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.18.0.0/1.18.30.32/Item.html
+++ b/1.18.0.0/1.18.30.32/Item.html
@@ -170,7 +170,7 @@ How long in seconds will this fuel cook items for.</br>Minimum value: 0.05</br>T
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.18.0.0/1.18.30.4/Item.html
+++ b/1.18.0.0/1.18.30.4/Item.html
@@ -169,7 +169,7 @@ How long in seconds will this fuel cook items for.</br>Minimum value: 0.05</br>T
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.18.0.0/1.18.31.4/Item.html
+++ b/1.18.0.0/1.18.31.4/Item.html
@@ -169,7 +169,7 @@ How long in seconds will this fuel cook items for.</br>Minimum value: 0.05</br>T
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.0.20/Item.html
+++ b/1.19.0.0/1.19.0.20/Item.html
@@ -180,7 +180,7 @@ How long in seconds will this fuel cook items for.</br>Minimum value: 0.05</br>T
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.0.24/Item.html
+++ b/1.19.0.0/1.19.0.24/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Minimum value: 0.05</br>T
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.0.26/Item.html
+++ b/1.19.0.0/1.19.0.26/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Minimum value: 0.05</br>T
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.0.28/Item.html
+++ b/1.19.0.0/1.19.0.28/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Minimum value: 0.05</br>T
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.0.30/Item.html
+++ b/1.19.0.0/1.19.0.30/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Minimum value: 0.05</br>T
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.0.32/Item.html
+++ b/1.19.0.0/1.19.0.32/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Minimum value: 0.05</br>T
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.0.34/Item.html
+++ b/1.19.0.0/1.19.0.34/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Minimum value: 0.05</br>T
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.0.5/Item.html
+++ b/1.19.0.0/1.19.0.5/Item.html
@@ -183,7 +183,7 @@ How long in seconds will this fuel cook items for.</br>Minimum value: 0.05</br>T
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.10.20/Item.html
+++ b/1.19.0.0/1.19.10.20/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Minimum value: 0.05</br>T
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.10.22/Item.html
+++ b/1.19.0.0/1.19.10.22/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.10.23/Item.html
+++ b/1.19.0.0/1.19.10.23/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.10.24/Item.html
+++ b/1.19.0.0/1.19.10.24/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.10.3/Item.html
+++ b/1.19.0.0/1.19.10.3/Item.html
@@ -183,7 +183,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.2.2/Item.html
+++ b/1.19.0.0/1.19.2.2/Item.html
@@ -183,7 +183,7 @@ How long in seconds will this fuel cook items for.</br>Minimum value: 0.05</br>T
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.20.2/Item.html
+++ b/1.19.0.0/1.19.20.2/Item.html
@@ -183,7 +183,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.20.20/Item.html
+++ b/1.19.0.0/1.19.20.20/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.20.22/Item.html
+++ b/1.19.0.0/1.19.20.22/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.20.23/Item.html
+++ b/1.19.0.0/1.19.20.23/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.20.24/Item.html
+++ b/1.19.0.0/1.19.20.24/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.30.20/Item.html
+++ b/1.19.0.0/1.19.30.20/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.30.21/Item.html
+++ b/1.19.0.0/1.19.30.21/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.30.22/Item.html
+++ b/1.19.0.0/1.19.30.22/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.30.23/Item.html
+++ b/1.19.0.0/1.19.30.23/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.30.4/Item.html
+++ b/1.19.0.0/1.19.30.4/Item.html
@@ -183,7 +183,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.40.2/Item.html
+++ b/1.19.0.0/1.19.40.2/Item.html
@@ -183,7 +183,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.40.20/Item.html
+++ b/1.19.0.0/1.19.40.20/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.40.21/Item.html
+++ b/1.19.0.0/1.19.40.21/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.40.22/Item.html
+++ b/1.19.0.0/1.19.40.22/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.40.23/Item.html
+++ b/1.19.0.0/1.19.40.23/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.50.2/Item.html
+++ b/1.19.0.0/1.19.50.2/Item.html
@@ -183,7 +183,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.50.20/Item.html
+++ b/1.19.0.0/1.19.50.20/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.50.21/Item.html
+++ b/1.19.0.0/1.19.50.21/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.50.22/Item.html
+++ b/1.19.0.0/1.19.50.22/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.50.23/Item.html
+++ b/1.19.0.0/1.19.50.23/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.50.24/Item.html
+++ b/1.19.0.0/1.19.50.24/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.50.25/Item.html
+++ b/1.19.0.0/1.19.50.25/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.60.20/Item.html
+++ b/1.19.0.0/1.19.60.20/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.60.22/Item.html
+++ b/1.19.0.0/1.19.60.22/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.60.23/Item.html
+++ b/1.19.0.0/1.19.60.23/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.60.24/Item.html
+++ b/1.19.0.0/1.19.60.24/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.60.25/Item.html
+++ b/1.19.0.0/1.19.60.25/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.60.26/Item.html
+++ b/1.19.0.0/1.19.60.26/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.60.27/Item.html
+++ b/1.19.0.0/1.19.60.27/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.60.3/Item.html
+++ b/1.19.0.0/1.19.60.3/Item.html
@@ -183,7 +183,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.70.2/Item.html
+++ b/1.19.0.0/1.19.70.2/Item.html
@@ -183,7 +183,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.70.20/Item.html
+++ b/1.19.0.0/1.19.70.20/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.70.21/Item.html
+++ b/1.19.0.0/1.19.70.21/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.70.22/Item.html
+++ b/1.19.0.0/1.19.70.22/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.70.23/Item.html
+++ b/1.19.0.0/1.19.70.23/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.70.24/Item.html
+++ b/1.19.0.0/1.19.70.24/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.70.26/Item.html
+++ b/1.19.0.0/1.19.70.26/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.80.2/Item.html
+++ b/1.19.0.0/1.19.80.2/Item.html
@@ -183,7 +183,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.80.20/Item.html
+++ b/1.19.0.0/1.19.80.20/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.80.21/Item.html
+++ b/1.19.0.0/1.19.80.21/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.80.22/Item.html
+++ b/1.19.0.0/1.19.80.22/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.80.23/Item.html
+++ b/1.19.0.0/1.19.80.23/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.19.0.0/1.19.80.24/Item.html
+++ b/1.19.0.0/1.19.80.24/Item.html
@@ -184,7 +184,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.20.0.0/1.20.0.20/Item.html
+++ b/1.20.0.0/1.20.0.20/Item.html
@@ -174,7 +174,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.20.0.0/1.20.0.21/Item.html
+++ b/1.20.0.0/1.20.0.21/Item.html
@@ -174,7 +174,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 

--- a/1.20.0.0/1.20.0.22/Item.html
+++ b/1.20.0.0/1.20.0.22/Item.html
@@ -174,7 +174,7 @@ How long in seconds will this fuel cook items for.</br>Type: float</br><a href="
 <td style="border-style:solid; border-width:3; padding:7px"></td>
 <td style="border-style:solid; border-width:3; padding:7px">The icon item component determines the icon to represent the item.</br>Experimental toggles required: Holiday Creator Features</br><h3><p id="legacy_id">legacy_id</p></h3>
 
-Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
+Legacy texture string id for older item icons. Legacy ID list can be found here under 'Namespaced ID': https://minecraft.wiki/w/Bedrock_Edition_data_values</br>Type: string</br><a href="#Index">Back to top</a><br><br>
 
 <h3><p id="texture">texture</p></h3>
 


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.